### PR TITLE
Added explicit references to os module in docs index

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
 //! - **uid:** The user’s ID
 //! - **name:** The user’s name
 //! - **primary_group:** The ID of this user’s primary group
+//! - [OS-specific extensions](os/index.html) such as home directories
 //!
 //! Here is a complete example that prints out the current user’s name:
 //!
@@ -95,6 +96,7 @@
 //!
 //! - **gid:** The group’s ID
 //! - **name:** The group’s name
+//! - [OS-specific extensions](os/index.html) such as lists of members
 //!
 //! And again, a complete example:
 //!


### PR DESCRIPTION
From a glance at the documentation index it seemed to me like no OS extensions exist, and that retrieving data such as user home directories is not supported.