### PR TITLE
Add `AllUsers` and `AllGroups`

### DIFF
--- a/examples/mocking.rs
+++ b/examples/mocking.rs
@@ -1,0 +1,40 @@
+extern crate uzers;
+
+use uzers::mock::MockUsers;
+use uzers::{AllGroups, Group, Groups, UsersCache, UsersSnapshot};
+
+fn iter_aware<G: Groups + AllGroups>(g: &G) {
+    println!("All groups:");
+    for group in g.get_all_groups() {
+        println!("- {group:?}");
+    }
+
+    no_iter(g);
+}
+
+fn no_iter<G: Groups>(g: &G) {
+    let me = g.get_current_groupname();
+    let root = g.get_group_by_gid(0);
+    println!("My group is {me:?}, gid 0 is {root:?}");
+}
+
+fn main() {
+    env_logger::init();
+
+    // UsersCache can only be used with `no_iter`
+    println!("\n--- UsersCache ---");
+    no_iter(&UsersCache::new());
+
+    // UsersSnapshot can be used with both `no_iter` and `iter_aware`
+    println!("\n--- UsersSnapshot: all groups ---");
+    no_iter(unsafe { &UsersSnapshot::new() });
+    println!("\n--- UsersSnapshot: primary groups of some system users ---");
+    iter_aware(unsafe { &UsersSnapshot::only_users(|u| u.uid() < 10) });
+
+    // MockUsers can be used with both `no_iter` and `iter_aware`
+    println!("\n--- MockUsers ---");
+    let mut mock = MockUsers::with_current_uid(1000);
+    mock.add_group(Group::new(1000, "fred"));
+    mock.add_group(Group::new(0, "r00t"));
+    iter_aware(&mock);
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -185,7 +185,17 @@ impl UsersCache {
         Self::default()
     }
 
-    /// Creates a new cache that contains all the users present on the system.
+    /// Creates a new cache preloaded with all users present on the system.
+    ///
+    /// This is a legacy method for code where `UsersCache` is required.
+    /// Consider replacing this method with [`UsersSnapshot::new`] whereever
+    /// possible to improve performance and consistency.
+    ///
+    /// Only information about *existing* users and groups is preloaded.
+    /// Consequently, the following requests will still result in system calls:
+    /// - current UID/GID,
+    /// - effective UID/GID,
+    /// - users and groups that were not preloaded.
     ///
     /// # Safety
     ///
@@ -200,6 +210,10 @@ impl UsersCache {
     ///
     /// let cache = unsafe { UsersCache::with_all_users() };
     /// ```
+    ///
+    /// # See also
+    ///
+    /// [`UsersSnapshot::new`]
     pub unsafe fn with_all_users() -> Self {
         let cache = Self::new();
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -214,6 +214,7 @@ impl UsersCache {
     /// # See also
     ///
     /// [`UsersSnapshot::new`]
+    #[deprecated(since = "0.11.4", note = "consider using `UsersSnapshot::new` instead")]
     pub unsafe fn with_all_users() -> Self {
         let cache = Self::new();
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -90,10 +90,11 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::hash::Hash;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use base::{all_users, Group, User};
-use traits::{Groups, Users};
+use traits::{AllUsers, Groups, Users};
 
 /// A producer of user and group instances that caches every result.
 ///
@@ -349,5 +350,128 @@ impl Groups for UsersCache {
     fn get_effective_groupname(&self) -> Option<Arc<OsStr>> {
         let gid = self.get_effective_gid();
         self.get_group_by_gid(gid).map(|g| Arc::clone(&g.name_arc))
+    }
+}
+
+/// A container of user instances.
+///
+/// `UsersSnapshot` collects system user data eagerly. See [`UsersCache`] for
+/// a lazy cache.
+#[derive(Default)]
+pub struct UsersSnapshot {
+    users: IdNameMap<uid_t, Arc<OsStr>, Arc<User>>,
+
+    uid: uid_t,
+    euid: uid_t,
+}
+
+impl UsersSnapshot {
+    /// Creates a new snapshot containing provided users.
+    pub(crate) fn from<U>(users: U, current_uid: uid_t, effective_uid: uid_t) -> Self
+    where
+        U: Iterator<Item = User>,
+    {
+        let mut user_map = IdNameMap::default();
+
+        for user in users {
+            user_map.insert(user.uid(), Arc::clone(&user.name_arc), Arc::from(user));
+        }
+
+        Self {
+            users: user_map,
+            uid: current_uid,
+            euid: effective_uid,
+        }
+    }
+
+    /// Creates a new snapshot containing all system users that pass the filter.
+    ///
+    /// # Safety
+    ///
+    /// This is `unsafe` because we cannot prevent data races if two caches
+    /// were attempted to be initialised on different threads at the same time.
+    /// For more information, see the [`all_users` documentation](../fn.all_users.html).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uzers::cache::UsersSnapshot;
+    ///
+    /// // Exclude Linux system users
+    /// let snapshot = unsafe { UsersSnapshot::filtered(|u| u.uid() >= 1000) };
+    /// ```
+    pub unsafe fn filtered<F>(filter: F) -> Self
+    where
+        F: FnMut(&User) -> bool,
+    {
+        Self::from(
+            all_users().filter(filter),
+            super::get_current_uid(),
+            super::get_effective_uid(),
+        )
+    }
+
+    /// Creates a new snapshot containing all system users.
+    ///
+    /// # Safety
+    ///
+    /// This is `unsafe` because we cannot prevent data races if two caches
+    /// were attempted to be initialised on different threads at the same time.
+    /// For more information, see the [`all_users` documentation](../fn.all_users.html).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uzers::cache::UsersSnapshot;
+    ///
+    /// let snapshot = unsafe { UsersSnapshot::new() };
+    /// ```
+    pub unsafe fn new() -> Self {
+        Self::filtered(|_| true)
+    }
+}
+
+impl AllUsers for UsersSnapshot {
+    type UserIter<'a> = std::iter::FilterMap<
+        std::collections::hash_map::Values<'a, uid_t, Option<Arc<User>>>,
+        for<'b> fn(&'b Option<Arc<User>>) -> Option<&'b User>,
+    >;
+
+    fn get_all_users(&self) -> Self::UserIter<'_> {
+        fn get_user(x: &Option<Arc<User>>) -> Option<&User> {
+            x.as_ref().map(Arc::deref)
+        }
+
+        self.users.forward.values().filter_map(get_user)
+    }
+}
+
+impl Users for UsersSnapshot {
+    fn get_user_by_uid(&self, uid: uid_t) -> Option<Arc<User>> {
+        self.users.forward.get(&uid)?.as_ref().cloned()
+    }
+
+    fn get_user_by_name<S: AsRef<OsStr> + ?Sized>(&self, username: &S) -> Option<Arc<User>> {
+        let name_arc = Arc::from(username.as_ref());
+        let uid = self.users.backward.get(&name_arc)?.as_ref()?;
+        self.get_user_by_uid(*uid)
+    }
+
+    fn get_current_uid(&self) -> uid_t {
+        self.uid
+    }
+
+    fn get_current_username(&self) -> Option<Arc<OsStr>> {
+        self.get_user_by_uid(self.uid)
+            .map(|u| Arc::clone(&u.name_arc))
+    }
+
+    fn get_effective_uid(&self) -> uid_t {
+        self.euid
+    }
+
+    fn get_effective_username(&self) -> Option<Arc<OsStr>> {
+        self.get_user_by_uid(self.euid)
+            .map(|u| Arc::clone(&u.name_arc))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,4 +151,4 @@ pub mod mock;
 pub mod switch;
 
 mod traits;
-pub use traits::{AllUsers, Groups, Users};
+pub use traits::{AllGroups, AllUsers, Groups, Users};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,13 +66,20 @@
 //! medium-length one may get away with caching the values to save on redundant
 //! system calls.
 //!
-//! For this reason, this crate offers a caching interface to the database,
-//! which offers the same functionality while holding on to every result,
-//! caching the information so it can be re-used.
+//! For this reason, this create offers two caching interfaces that expose the
+//! same functionality while reducing system calls:
+//! [`UsersCache`](cache/struct.UsersCache.html) and
+//! [`UsersSnapshot`](cache/struct.UsersSnapshot.html). `UsersCache` is a lazy
+//! cache, storing answers as they arrive from the OS. `UsersSnapshot` is an
+//! eager cache, querying all data at once when constructed.
 //!
-//! To introduce a cache, create a new
+//! `UsersCache` has a smaller memory and performance overhead, while
+//! `UsersSnapshot` offers better consistency and allows iterating over users
+//! and groups.
+//!
+//! For example, to introduce a lazy cache, create a new
 //! [`UsersCache`](cache/struct.UsersCache.html). It has functions with the
-//! same names as the ones from earlier. For example:
+//! same names as the ones from earlier:
 //!
 //! ```
 //! use uzers::{Users, Groups, UsersCache};
@@ -83,10 +90,8 @@
 //! println!("Hello again, {}!", user.name().to_string_lossy());
 //! ```
 //!
-//! This cache is **only additive**: it’s not possible to drop it, or erase
-//! selected entries, as when the database may have been modified, it’s best to
-//! start entirely afresh. So to accomplish this, just start using a new
-//! `UsersCache`.
+//! See documentation for [`UsersCache`](cache/struct.UsersCache.html) and
+//! [`UsersSnapshot`](cache/struct.UsersSnapshot.html) for more details.
 //!
 //!
 //! ## Groups

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ pub mod cache;
 
 #[cfg(feature = "cache")]
 pub use cache::UsersCache;
+pub use cache::UsersSnapshot;
 
 #[cfg(feature = "mock")]
 pub mod mock;
@@ -150,4 +151,4 @@ pub mod mock;
 pub mod switch;
 
 mod traits;
-pub use traits::{Groups, Users};
+pub use traits::{AllUsers, Groups, Users};

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -63,7 +63,7 @@ use std::sync::Arc;
 
 pub use base::{Group, User};
 pub use libc::{gid_t, uid_t};
-pub use traits::{AllUsers, Groups, Users};
+pub use traits::{AllGroups, AllUsers, Groups, Users};
 
 /// A mocking users table that you can add your own users and groups to.
 pub struct MockUsers {
@@ -159,6 +159,17 @@ impl AllUsers for MockUsers {
 
     fn get_all_users(&self) -> Self::UserIter<'_> {
         self.users.values().map(Arc::deref)
+    }
+}
+
+impl AllGroups for MockUsers {
+    type GroupIter<'a> = std::iter::Map<
+        std::collections::hash_map::Values<'a, gid_t, Arc<Group>>,
+        for<'b> fn(&'b Arc<Group>) -> &'b Group,
+    >;
+
+    fn get_all_groups(&self) -> Self::GroupIter<'_> {
+        self.groups.values().map(Arc::deref)
     }
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -34,7 +34,7 @@
 //!
 //! To set your program up to use either type of `Users` table, make your
 //! functions and structs accept a generic parameter that implements the `Users`
-//! trait. Then, you can pass in a value of either Cache or Mock type.
+//! trait. Then, you can pass in a value of either Cache, Snapshot or Mock type.
 //!
 //! Here’s a complete example:
 //!
@@ -55,6 +55,26 @@
 //! let mut actual_users = UsersCache::new();
 //! print_current_username(&mut actual_users);
 //! ```
+//!
+//! Include `AllUsers` in generic parameter bounds if iteration is required:
+//!
+//! ```
+//! use uzers::{AllUsers, User, Users, UsersSnapshot};
+//! use uzers::mock::MockUsers;
+//!
+//! fn print_all_users<U: Users + AllUsers>(users: &U) {
+//!     println!("All users:");
+//!     for user in users.get_all_users() {
+//!         println!("- {:?}", user.name());
+//!     }
+//! }
+//!
+//! let mut users = MockUsers::with_current_uid(1001);
+//! users.add_user(User::new(1001, "fred", 101));
+//! print_all_users(&users);
+//!
+//! let actual_users = unsafe { UsersSnapshot::new() };
+//! print_all_users(&users);
 
 use std::collections::HashMap;
 use std::ffi::OsStr;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -197,7 +197,7 @@ impl AllGroups for MockUsers {
 mod test {
     use super::MockUsers;
     use base::{Group, User};
-    use traits::{Groups, Users};
+    use traits::{AllGroups, AllUsers, Groups, Users};
 
     use std::ffi::OsStr;
     use std::sync::Arc;
@@ -252,6 +252,16 @@ mod test {
     }
 
     #[test]
+    fn all_users() {
+        let mut users = MockUsers::with_current_uid(1337);
+        users.add_user(User::new(1337, "fred", 101));
+        assert_eq!(
+            vec![1337],
+            users.get_all_users().map(|u| u.uid()).collect::<Vec<_>>()
+        )
+    }
+
+    #[test]
     fn gid() {
         let mut users = MockUsers::with_current_uid(0);
         users.add_group(Group::new(1337, "fred"));
@@ -285,6 +295,16 @@ mod test {
             users
                 .get_group_by_gid(1337)
                 .map(|g| Arc::clone(&g.name_arc))
+        )
+    }
+
+    #[test]
+    fn all_groups() {
+        let mut users = MockUsers::with_current_uid(1337);
+        users.add_group(Group::new(1337, "fred"));
+        assert_eq!(
+            vec![1337],
+            users.get_all_groups().map(|g| g.gid()).collect::<Vec<_>>()
         )
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -54,7 +54,7 @@ pub trait AllUsers {
     where
         Self: 'a;
 
-    /// Creates a new iterator over every user present on the system.
+    /// Creates a new iterator over every user.
     fn get_all_users(&self) -> Self::UserIter<'_>;
 }
 
@@ -65,6 +65,6 @@ pub trait AllGroups {
     where
         Self: 'a;
 
-    /// Creates a new iterator over every group present on the system.
+    /// Creates a new iterator over every group.
     fn get_all_groups(&self) -> Self::GroupIter<'_>;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -46,3 +46,14 @@ pub trait Groups {
     /// Returns the effective group name.
     fn get_effective_groupname(&self) -> Option<Arc<OsStr>>;
 }
+
+/// Trait for providers of user iterators.
+pub trait AllUsers {
+    /// [`User`] iterator returned by [`get_all_users`][Self::get_all_users].
+    type UserIter<'a>: Iterator<Item = &'a User>
+    where
+        Self: 'a;
+
+    /// Creates a new iterator over every user present on the system.
+    fn get_all_users(&self) -> Self::UserIter<'_>;
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -57,3 +57,14 @@ pub trait AllUsers {
     /// Creates a new iterator over every user present on the system.
     fn get_all_users(&self) -> Self::UserIter<'_>;
 }
+
+/// Trait for providers of group iterators.
+pub trait AllGroups {
+    /// [`Group`] iterator returned by [`get_all_groups`][Self::get_all_groups].
+    type GroupIter<'a>: Iterator<Item = &'a Group>
+    where
+        Self: 'a;
+
+    /// Creates a new iterator over every group present on the system.
+    fn get_all_groups(&self) -> Self::GroupIter<'_>;
+}


### PR DESCRIPTION
`AllUsers` and `AllGroups` are traits that provide `all_users()` and `all_groups()` similar to how `Users` and `Groups` provide other library functions. Also included is `UsersSnapshot`, a pre-loaded version of `UsersCache` that can iterate over its contents safely. `MockUsers` now also implements `AllUsers` and `AllGroups`.

Resolves #10.

## Example usage

```rust
fn old_consumer<U: Users>(u: &U) {
    println!("{:?}", u.get_current_username());
}

fn new_consumer<U: Users + AllUsers>(u: &U) {
    for user in u.get_all_users() { // This call is safe
        println!("{user:?}");
    }
    old_consumer(u);
}

fn main() {
    // The unsafe `all_users` call happens here
    let snapshot = unsafe { UsersSnapshot::new() };
    new_consumer(&snapshot);

    let mut mock = MockUsers::with_current_uid(1234);
    mock.add_user(User::new(1234, "tom", 1234));
    new_consumer(&mock);
}
```
---
Checklist:
- [x] `AllUsers`
- [x] `AllGroups`
- [x] `UsersSnapshot`
- [x] Implement new traits in `MockUsers`
- [x] Update docs
- [x] Add tests