### PR TITLE
Add GECOS field on UNIX systems.

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -1418,10 +1418,11 @@ mod test {
         // Not a real test but can be used to verify correct results
         // Use with --nocapture on test executable to show output
         println!(
-            "HOME={:?}, SHELL={:?}, PASSWD={:?}",
+            "HOME={:?}, SHELL={:?}, PASSWD={:?}, GECOS={:?}",
             user.home_dir(),
             user.shell(),
-            user.password()
+            user.password(),
+            user.gecos()
         );
     }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -1070,6 +1070,14 @@ pub mod os {
             /// Can be used to construct tests users, which by default come with a
             /// dummy password field.
             fn with_password<S: AsRef<OsStr> + ?Sized>(self, password: &S) -> Self;
+
+            /// Returns the user's GECOS comment
+            fn gecos(&self) -> &OsStr;
+
+            /// Sets this user's GECOS comment to the given string.
+            /// Can be used to construct tests users, which by default come with a
+            /// dummy GECOS field.
+            fn with_gecos<S: AsRef<OsStr> + ?Sized>(self, gecos: &S) -> Self;
         }
 
         /// Unix-specific extensions for `Group`s.
@@ -1093,6 +1101,9 @@ pub mod os {
 
             /// The user’s encrypted password.
             pub password: OsString,
+
+            /// The user's GECOS comment
+            pub gecos: OsString,
         }
 
         impl Default for UserExtras {
@@ -1101,6 +1112,7 @@ pub mod os {
                     home_dir: "/var/empty".into(),
                     shell: "/bin/false".into(),
                     password: "*".into(),
+                    gecos: "".into(),
                 }
             }
         }
@@ -1118,11 +1130,13 @@ pub mod os {
                     let home_dir = from_raw_buf::<OsString>(passwd.pw_dir).into();
                     let shell = from_raw_buf::<OsString>(passwd.pw_shell).into();
                     let password = from_raw_buf::<OsString>(passwd.pw_passwd);
+                    let gecos = from_raw_buf::<OsString>(passwd.pw_gecos);
 
                     Self {
                         home_dir,
                         shell,
                         password,
+                        gecos,
                     }
                 }
             }
@@ -1171,6 +1185,15 @@ pub mod os {
 
             fn with_password<S: AsRef<OsStr> + ?Sized>(mut self, password: &S) -> Self {
                 self.extras.password = password.into();
+                self
+            }
+
+            fn gecos(&self) -> &OsStr {
+                &self.extras.gecos
+            }
+
+            fn with_gecos<S: AsRef<OsStr> + ?Sized>(mut self, gecos: &S) -> Self {
+                self.extras.gecos = gecos.into();
                 self
             }
         }
@@ -1272,6 +1295,15 @@ pub mod os {
 
             fn with_password<S: AsRef<OsStr> + ?Sized>(mut self, password: &S) -> Self {
                 self.extras.extras.password = password.into();
+                self
+            }
+
+            fn gecos(&self) -> &OsStr {
+                &self.extras.extras.gecos
+            }
+
+            fn with_gecos<S: AsRef<OsStr> + ?Sized>(mut self, gecos: &S) -> Self {
+                self.extras.extras.gecos = gecos.into();
                 self
             }
         }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -307,4 +307,34 @@ mod test {
             users.get_all_groups().map(|g| g.gid()).collect::<Vec<_>>()
         )
     }
+
+    #[test]
+    fn gecos() {
+        use crate::os::unix::UserExt;
+
+        let mut users = MockUsers::with_current_uid(1337);
+        users.add_user(User::new(1337, "fred", 101).with_gecos("Fred Santa"));
+
+        assert_eq!(
+            Some("Fred Santa".to_string()),
+            users
+                .get_user_by_uid(1337)
+                .map(|u| u.gecos().to_string_lossy().to_string())
+        );
+    }
+
+    #[test]
+    fn no_gecos() {
+        use crate::os::unix::UserExt;
+
+        let mut users = MockUsers::with_current_uid(1337);
+        users.add_user(User::new(1337, "fred", 101));
+
+        assert_eq!(
+            Some("".to_string()),
+            users
+                .get_user_by_uid(1337)
+                .map(|u| u.gecos().to_string_lossy().to_string())
+        );
+    }
 }


### PR DESCRIPTION
This pull request adds the comment field (GECOS) that should be present on UNIX systems to the `UserExtras` struct as an `Option<OsString>`. The field would be `None` if the field is empty.

Refers to #12.