### PR TITLE
Test CI with nss_preload.

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -12,9 +12,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - run: |
+          sudo apt update && sudo apt install -y libnss-wrapper
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test
+        env:
+          NSS_WRAPPER_PASSWD: tests/fixtures/passwd
+          NSS_WRAPPER_GROUP: tests/fixtures/group
+        run: |
+          cargo test
+          LD_PRELOAD=libnss_wrapper.so cargo test --features test-integration mocked_
+          LD_PRELOAD=libnss_wrapper.so cargo test --features test-integration --test '*'
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default = ["cache", "mock", "logging"]
 cache = []
 mock = []
 logging = ["log"]
+test-integration = []
 
 [dependencies.libc]
 version = "0.2"
@@ -30,3 +31,6 @@ default_features = false
 version = "0.7"
 default_features = false
 features = []
+
+[dev_dependencies.serial_test]
+version = "^2.0"

--- a/src/base.rs
+++ b/src/base.rs
@@ -1433,3 +1433,65 @@ mod test {
         assert!(group.is_none());
     }
 }
+
+#[cfg(all(test, feature = "test-integration"))]
+mod mocked_test {
+    extern crate serial_test;
+
+    use self::serial_test::serial;
+
+    use super::{os::unix::GroupExt, *};
+
+    #[test]
+    #[serial]
+    fn mocked_username() {
+        let user = get_user_by_uid(1337).unwrap();
+
+        assert_eq!(user.name(), "fred");
+    }
+
+    #[test]
+    #[serial]
+    fn mocked_uid_for_uid() {
+        let user = get_user_by_uid(1337).unwrap();
+
+        assert_eq!(user.uid, 1337);
+    }
+
+    #[test]
+    #[serial]
+    fn mocked_user_by_name() {
+        let user_by_name = get_user_by_name("fred");
+
+        assert!(user_by_name.is_some());
+        assert_eq!(user_by_name.unwrap().name(), "fred");
+
+        // User names containing '\0' cannot be used (for now)
+        let user = get_user_by_name("user\0");
+        assert!(user.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn mocked_group_by_name() {
+        let group_by_name = get_group_by_name("bosses");
+
+        assert!(group_by_name.is_some());
+        assert_eq!(group_by_name.unwrap().name(), "bosses");
+
+        // Group names containing '\0' cannot be used (for now)
+        let group = get_group_by_name("users\0");
+        assert!(group.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn mocked_group_members() {
+        let group = get_group_by_gid(43).unwrap();
+        let members = group.members();
+
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&"bob".into()));
+        assert!(members.contains(&"martha".into()));
+    }
+}

--- a/tests/fixtures/group
+++ b/tests/fixtures/group
@@ -1,0 +1,2 @@
+bosses:x:42:
+contributors:x:43:bob,martha

--- a/tests/fixtures/passwd
+++ b/tests/fixtures/passwd
@@ -1,0 +1,1 @@
+fred:x:1337:42:Fred Santa:/home/fred:/usr/bin/nologin

--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -1,0 +1,16 @@
+extern crate uzers;
+
+#[cfg(feature = "test-integration")]
+mod integration {
+    #[test]
+    fn test_group_by_name() {
+        let group = uzers::get_group_by_name("bosses");
+
+        assert_eq!(group.is_some(), true);
+
+        let group = group.unwrap();
+
+        assert_eq!(group.gid(), 42);
+        assert_eq!(group.name(), "bosses");
+    }
+}

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -1,0 +1,22 @@
+extern crate uzers;
+
+#[cfg(feature = "test-integration")]
+mod integration {
+    use std::path::PathBuf;
+
+    use uzers::os::unix::UserExt;
+
+    #[test]
+    fn test_user_by_name() {
+        let user = uzers::get_user_by_name("fred");
+
+        assert_eq!(user.is_some(), true);
+
+        let user = user.unwrap();
+
+        assert_eq!(user.uid(), 1337);
+        assert_eq!(user.name(), "fred");
+        assert_eq!(user.primary_group_id(), 42);
+        assert_eq!(user.home_dir(), PathBuf::from("/home/fred"));
+    }
+}


### PR DESCRIPTION
This pull requests creates the foundation to be able to test this library end to end. Right now, it uses the mock interface and dummy users to verify behavior, which completely circumvents calls to `libc` and therefore to NSS.

This adds new tests, which runs **must** be separate from the general tests, and require the use of `libnss_wrapper` in `LD_PRELOAD` to add fixture users that are actually going to be returned by `libc`.

Note that the existing tests cannot be run with this, because the "current user" that it uses is not present in the fixtured data.

All mocked tests are defined under a feature called `test-integration` and will only be executed when the feature is set. Also, and I am not entirely satisfied by this, in order to only run the new tests when wrapping NSS, they are all prefixed with `mocked_` right now (I neither like the naming nor the concept). We then only execute tests with that prefix for that phase.

Ultimately, the three rounds of tests that are performed are:

 * `cargo test`: same as before, nothing changes
 * `LD_PRELOAD=... cargo test --features test-integration mocked_`: run new unit tests
 * LD_PRELOAD=... `cargo test --features test-integration --test '*'`: run new integration tests

That way, current users can still run the usual test suite without any impact, and CI (or users willing to install `libnss_wrapper`) can run the whole suite.

I have taken the liberty to rewrite some of the unit test in `base.rs` to take advantage of the fixtures (in a separate test module for clarity) to show how it could be done.

Please add remarks, this came out of a prototype, and there are some things I am still not a fan of.

Related to #14.

**Note:** the `serial_test` crate was added to prevent unit tests that actually interact with `libc` from running in parallel, to prevent known thread-safety issues.