### PR TITLE
Fix disabling the cache feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ version = "0.2"
 [dependencies.log]
 version = "0.4"
 optional = true
-default_features = false
+default-features = false
 
-[dev_dependencies.env_logger]
+[dev-dependencies.env_logger]
 version = "0.7"
-default_features = false
+default-features = false
 features = []
 
-[dev_dependencies.serial_test]
+[dev-dependencies.serial_test]
 version = "^2.0"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -28,9 +28,9 @@
 //! and group lookups. Rust provides mutability in two ways:
 //!
 //! 1. Have its methods take `&mut self`, instead of `&self`, allowing the
-//!   internal maps to be mutated (“inherited mutability”)
+//!    internal maps to be mutated (“inherited mutability”)
 //! 2. Wrap the internal maps in a `RefCell`, allowing them to be modified
-//!   (“interior mutability”).
+//!    (“interior mutability”).
 //!
 //! Unfortunately, Rust is also very protective of references to a mutable
 //! value. In this case, switching to `&mut self` would only allow for one user

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,8 +147,7 @@ pub use base::{os, Group, User};
 pub mod cache;
 
 #[cfg(feature = "cache")]
-pub use cache::UsersCache;
-pub use cache::UsersSnapshot;
+pub use cache::{UsersCache, UsersSnapshot};
 
 #[cfg(feature = "mock")]
 pub mod mock;


### PR DESCRIPTION
The `#[cfg]` only applies to the following line. Othewise, building without the feature yields:


```
$ cargo build --no-default-features
    Updating crates.io index
   Compiling libc v0.2.155
   Compiling uzers v0.12.0 (/home/ayats/Documents/uzers-rs)
error[E0432]: unresolved import `cache`
   --> src/lib.rs:151:9
    |
151 | pub use cache::UsersSnapshot;
    |         ^^^^^ maybe a missing crate `cache`?
    |
    = help: consider adding `extern crate cache` to use the `cache` crate

For more information about this error, try `rustc --explain E0432`.
error: could not compile `uzers` (lib) due to 1 previous error
```