### PR TITLE
test: add tests on linux/arm64, macOS, nightly

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,19 +25,86 @@ env:
 
 jobs:
   test:
-    name: Test
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: "Linux"
+            arch: "x86_64"
+            host: "ubuntu-latest"
+            toolchain: "stable"
+            run_unit_tests: true
+            run_integration_tests: true
+
+          # Test with nightly to preview future issues
+          - os: "Linux"
+            arch: "x86_64"
+            host: "ubuntu-latest"
+            toolchain: "nightly"
+            run_unit_tests: true
+            run_integration_tests: true
+
+          # Test minimum Rust version our crate builds with
+          - os: "Linux"
+            arch: "x86_64"
+            host: "ubuntu-latest"
+            toolchain: "1.65.0"
+            # Tests depend on env_logger, which has an MSRV of 1.71.0
+            run_unit_tests: false
+            run_integration_tests: false
+
+          # Test minimum Rust version our tests pass on
+          - os: "Linux"
+            arch: "x86_64"
+            host: "ubuntu-latest"
+            toolchain: "1.71.0"
+            run_unit_tests: true
+            run_integration_tests: true
+
+          - os: "Linux"
+            arch: "arm64"
+            host: "ubuntu-24.04-arm"
+            toolchain: "stable"
+            run_unit_tests: true
+            run_integration_tests: true
+
+          - os: "macOS"
+            arch: "arm64"
+            host: "macos-latest"
+            toolchain: "stable"
+            run_unit_tests: true
+            # We aren't yet ready to run integration tests on macOS; will need to figure out nss wrapper.
+            run_integration_tests: false
+
+    name: "Test (${{ matrix.os }}/${{ matrix.arch }}/${{ matrix.toolchain }})"
+    runs-on: ${{ matrix.host }}
     steps:
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
       - uses: Swatinem/rust-cache@v2
-      - name: Run tests
+        with:
+          key: ${{ matrix.host }}-${{ matrix.toolchain }}
+
+      - name: Build default targets
+        run: |
+          cargo build
+
+      - name: Run unit tests
+        if: ${{ matrix.run_unit_tests }}
+        run: |
+          cargo test
+
+      - name: Run integration tests
+        if: ${{ matrix.run_integration_tests }}
         env:
           NSS_WRAPPER_PASSWD: tests/fixtures/passwd
           NSS_WRAPPER_GROUP: tests/fixtures/group
         run: |
           sudo apt update && sudo apt install -y libnss-wrapper
-          cargo test
           LD_PRELOAD=libnss_wrapper.so cargo test --features test-integration mocked_
           LD_PRELOAD=libnss_wrapper.so cargo test --features test-integration --test '*'
 

--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -3,6 +3,7 @@ extern crate uzers;
 #[cfg(feature = "test-integration")]
 mod integration {
     #[test]
+    #[serial_test::serial]
     fn test_group_by_name() {
         let group = uzers::get_group_by_name("bosses");
 
@@ -12,5 +13,20 @@ mod integration {
 
         assert_eq!(group.gid(), 42);
         assert_eq!(group.name(), "bosses");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_all_groups() {
+        let groups: Vec<_> = unsafe { uzers::all_groups() }.collect();
+        assert_eq!(groups.len(), 2);
+
+        let group = &groups[0];
+        assert_eq!(group.gid(), 42);
+        assert_eq!(group.name(), "bosses");
+
+        let group = &groups[1];
+        assert_eq!(group.gid(), 43);
+        assert_eq!(group.name(), "contributors");
     }
 }

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -7,6 +7,7 @@ mod integration {
     use uzers::os::unix::UserExt;
 
     #[test]
+    #[serial_test::serial]
     fn test_user_by_name() {
         let user = uzers::get_user_by_name("fred");
 
@@ -14,6 +15,19 @@ mod integration {
 
         let user = user.unwrap();
 
+        assert_eq!(user.uid(), 1337);
+        assert_eq!(user.name(), "fred");
+        assert_eq!(user.primary_group_id(), 42);
+        assert_eq!(user.home_dir(), PathBuf::from("/home/fred"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_all_users() {
+        let users: Vec<_> = unsafe { uzers::all_users() }.collect();
+        assert_eq!(users.len(), 1);
+
+        let user = users.first().unwrap();
         assert_eq!(user.uid(), 1337);
         assert_eq!(user.name(), "fred");
         assert_eq!(user.primary_group_id(), 42);


### PR DESCRIPTION
Taking inspiration from #23, expands PR/CI testing via matrix:

* Adds *build-only validation* on `1.65.0` (see below)
* Adds test validation on `1.71.0`, `stable`, and `nightly` (x86_64/Linux)
* Adds test validation on arm64 Linux (`stable`)
* Adds unit-test-only validation on macOS (`stable`)

Also adds 2 basic integration tests for `all_users` and `all_groups`.

---

Notes:

* Regarding min Rust versions, I used `cargo msrv` to empirically compute the effective MSRV of this crate as `1.65.0`. I then discovered that the dev dependency on `env_logger` for testing raises the minimum for *testing* as being `1.71.0`. I ended up adding both to the matrix, disabling test execution on the older version.

* On macOS, `libnss_wrapper` doesn't appear available so I've only enabled _unit tests_ there until an alternate strategy could be adopted.

Potential future work:

* Formally document MSRV via metadata in `Cargo.toml`.
* At least validate build for alternate targets (e.g., BSD families) using `cross` or `cargo --target`.
* Explore use of [vmactions GitHub actions](https://github.com/vmactions) for running build-and-test on alternate OSes using VMs hosted in PR/CI workflows.